### PR TITLE
add comments to imply that we can stop the mail sending when TO: is b…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # SesBlacklistRails
+
 [![Gem Version](https://badge.fury.io/rb/ses_blacklist_rails.svg)](https://badge.fury.io/rb/ses_blacklist_rails)
 [![CircleCI](https://circleci.com/gh/mrdShinse/sns_blacklist_rails/tree/master.svg?style=svg)](https://circleci.com/gh/mrdShinse/sns_blacklist_rails/tree/master)
 [![Maintainability](https://api.codeclimate.com/v1/badges/4f1e146157fdfacbdde1/maintainability)](https://codeclimate.com/github/mrdShinse/sns_blacklist_rails/maintainability)
 [![Dependency Status](https://gemnasium.com/badges/github.com/mrdShinse/sns_blacklist_rails.svg)](https://gemnasium.com/github.com/mrdShinse/sns_blacklist_rails)
 
 ## Installation
+
 Add this line to your application's `Gemfile`:
 
 ```ruby
@@ -12,6 +14,7 @@ gem 'ses_blacklist_rails'
 ```
 
 And then execute:
+
 ```bash
 $ bundle
 $ bundle exec rails g ses_blacklist_rails:install
@@ -20,10 +23,14 @@ $ bundle exec rails g ses_blacklist_rails:install
 ## Configuration
 
 `in config/initializers/ses_blacklist_rails.rb`
+
 ```ruby
 SesBlacklistRails.configure do |config|
   config.send_bounce = false
   config.send_complaint = false
+
+  # send the mail to config.default_address when the TO: address is bounce or complaint before.
+  # set to '' to stop the mail sending when bounce or complaint.
   config.default_address = 'some_address@sample.com'
 end
 
@@ -31,7 +38,9 @@ ActionMailer::Base.register_interceptor(::SesBlacklistRails::ActionMailIntercept
 ```
 
 ## Contributing
+
 Please let me know if you found any problems, by creating ISSUE reports or PRs.
 
 ## License
+
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
…ounce or complaint

### Context
- the current README.md doesn't show that we can stop the mail sending if the TO: address used is bounce or complaint.

### How has this been tested?
- tested on local development environment by setting the `config.default_address` to `''`.

### Types of changes
- adding comments to `config.default_address` .
